### PR TITLE
Fix the occlusions on the enemy status page

### DIFF
--- a/app/src/main/res/layout/activity_enemy_stats.xml
+++ b/app/src/main/res/layout/activity_enemy_stats.xml
@@ -8,7 +8,7 @@
         android:id="@+id/grid_enemies"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:numColumns="2"
+        android:numColumns="1"
         android:paddingLeft="10dp"
         android:paddingRight="10dp"
         android:paddingTop="10dp"

--- a/app/src/main/res/layout/item_enemy.xml
+++ b/app/src/main/res/layout/item_enemy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="185dp"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
     android:scaleType="fitCenter">
 


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #193, and I have fixed the occlusions on the enemy status page by slightly adjusting the number of columns and the heights of status cards. I would genuinely appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/131948035-9d690a64-001d-432c-9e52-72353d907ba1.png" alt="copy" width="250"/>

Thanks again! Blessings on your day! :)